### PR TITLE
fix README: s/bunayn/bunyan/g; typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ A logger module for [Nestjs](https://github.com/nestjs/nest), built on top of [n
 
 ### Yarn
 ```
-yarn add @wiredcraft/nestjs-bunayn-logger
+yarn add @wiredcraft/nestjs-bunyan-logger
 ```
 
 ### NPM
 ```
-npm install @wiredcraft/nestjs-bunayn-logger --save
+npm install @wiredcraft/nestjs-bunyan-logger --save
 ```
 
 ## Integration


### PR DESCRIPTION
## What did I do?

```
s/bunayn/bunyan/g;
```

## How important this fix is

I have tried to install this `nestjs-bunyan-logger` to my app, copy-n-pasted the `yarn` command a hundred times from README, all in vain.

```
% yarn add "@wiredcraft/nestjs-bunayn-logger"
yarn add v1.22.19
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@wiredcraft%2fnestjs-bunayn-logger: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/sugitak/***/***/***/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

The reason was simple; there was a small typo in this first instruction!

```diff
- yarn add @wiredcraft/nestjs-bunayn-logger
+ yarn add @wiredcraft/nestjs-bunyan-logger
```

I feel this repository is too far underestimated, and one reason may be because of this typo, which may have lead many users to give up their installation in their first few minutes.